### PR TITLE
Add Docker file to construct a build environment easily for Asciidoc

### DIFF
--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:utopic
+
+RUN apt-get update
+RUN apt-get -y install git asciidoc po4a dblatex gettext make pandoc texlive-lang-*
+
+ADD ./make.docker.sh /opt/make.docker.sh

--- a/utils/docker/README.adoc
+++ b/utils/docker/README.adoc
@@ -1,0 +1,12 @@
+This is a Docker image builder that produces an environment capable of building
+the KiCad documentation.
+
+.Method
+* Clone the docs
+** `git clone https://github.com/ciampix/kicad-doc`
+* Build the Docker image (you only need to do this once, or if you change the Dockerfile
+  or files that go into the image:
+** `docker build -t kicad-docs .`
+* Run the build script within docker:
+** `docker run -v /your/src/dir/:/mnt/src/kicad-docs kicad-docs /opt/make.docker.sh`
+

--- a/utils/docker/make.docker.sh
+++ b/utils/docker/make.docker.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+# Script to build the KiCad docs within a Docker container
+#
+
+# where the docs are pulled down to
+adocRoot=/mnt/src/kicad-doc/src/asciidoc
+
+# function build each sub directory
+function makeAll {
+        cd "$adocRoot/$1"
+            ./make.sh all-all
+}
+
+cd "$adocRoot"
+
+# build each sub directory
+makeAll KiCad
+makeAll Eeschema
+makeAll IDF_Exporter
+makeAll CvPcb


### PR DESCRIPTION
Here's a very simple Docker image to allow you to set up a documentations build environment on any Docker-capable machine. Could be good for a Jenkins, Windows user or just for building without installing GBs of packages to your machine.