### PR TITLE
Fix Issue #51 (CMake bulid incomplete)

### DIFF
--- a/CMakeModules/FindASCIIDOCTORPDF.cmake
+++ b/CMakeModules/FindASCIIDOCTORPDF.cmake
@@ -41,7 +41,7 @@ else()
 endif()
 
 if( ASCIIDOCTORPDF_FOUND )
-    # Get the PO4A version number...
+    # Get the asciidoctor-pdf version number...
     string( REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" ADOC_VERSION "${_ADOC_EXE_OUTPUT}" )
     message( STATUS "ASCIIDOCTORPDF Found v${ADOC_VERSION}" )
 else()

--- a/CMakeModules/FindDBLATEX.cmake
+++ b/CMakeModules/FindDBLATEX.cmake
@@ -6,7 +6,7 @@
 # executable and there's no direct binary that we can find, so we also try to find python and
 # discover the dblatex "script" from there
 #
-# Variables generatied:
+# Variables generated:
 #
 # DBLATEX_FOUND     true when DBLATEX_COMMAND and DBLATEX_VERSION have valid entries
 # DBLATEX_COMMAND   The command to run dblatex (may be a list including an interpreter)
@@ -15,7 +15,6 @@
 
 # Have a go at finding a dblatex executable (valid for POSIX systems, not for WIN systems)
 find_program( DBLATEX_COMMAND dblatex )
-message( STATUS "find_program( DBLATEX_COMMAND dblatex ): ${DBLATEX_COMMAND}" )
 
 # If nothing could be found, test to see if we can just find the file, that we'll then run with the
 # python interpreter

--- a/CMakeModules/FindPO4A.cmake
+++ b/CMakeModules/FindPO4A.cmake
@@ -4,15 +4,14 @@
 #
 # CMake module to find po4a (PO for anything).
 #
-# Variables generatied:
+# Variables generated:
 #
 # PO4A_FOUND     true when PO4A_COMMAND is valid
 # PO4A_COMMAND   The command to run po4a (may be a list including an interpreter)
-# PO4A_GETTEXTIZE_COMMAND   The command to run po4a-gettextize (may be a list including an interpreter)
-# PO4A_VERSION   The a2x version that has been found
+# PO4A_VERSION   The po4a version that has been found
 #
 
-# Have a go at finding a a2x executable
+# Have a go at finding a po4a executable
 find_program( PO4A_COMMAND po4a )
 
 # If nothing could be found, test to see if we can just find the script file, that we'll then run


### PR DESCRIPTION
This fixes #51 by re-organising the build so that documents are created in a language-specific folder rather than have a language-specific filename. This allows asciidoc includes to be used correctly without fear of having to modify the asciidoc document in order to "force" them to work.

This solution is much better suited to a CMake build system rather than trying to modify the include files. It does not impact on the original Makefile method.

This solution is a little wasteful in including a copy of the images folder in all language html install folders, but this could be dealt with by using relative links or similar (to be discussed if it's a problem).