### PR TITLE
* Fixes #58 - provides SINGLE_LANGUAGE option when configuring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,10 @@ set( PDF_GENERATOR "DBLATEX" CACHE STRING "Specify which PDF generator to use: D
 
 # Provide an option for a single language build. If nothing else, this will at
 # least help developers to speed up a build they're working on
-set( SINGLE_LANGUAGE "" CACHE STRING "Specify a single language to build: en|fr|it|pl" )
+set( SINGLE_LANGUAGE "" CACHE STRING "Specify a single language to build: en|fr|it|nl|pl" )
+
+# Provide an option to decide which documentation formats to build.
+set( BUILD_FORMATS "html;pdf" CACHE LIST "Specify which output formats to build html/pdf" )
 
 # Add our custom modules to the module path
 set( CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMakeModules" ${CMAKE_MODULE_PATH} )
@@ -79,10 +82,19 @@ else()
     set( PACKAGE_LANGUAGE "-${SINGLE_LANGUAGE}" )
 endif()
 
+# If there is more than one build format, do not bother transforming the
+# package name, otherwise if there's only one, add it to the package name
+list( LENGTH BUILD_FORMATS BUILD_FORMATS_LENGTH )
+if( ${BUILD_FORMATS_LENGTH} GREATER 1 )
+    set( PACKAGE_BUILD_FORMAT "" )
+else()
+    set( PACKAGE_BUILD_FORMAT "-${BUILD_FORMATS}" )
+endif()
+
 # Generate both .tar.gz and .zip package targets
 set( CPACK_GENERATOR "TGZ;ZIP" )
 set( CPACK_PACKAGE_VERSION "1.0.0" )
-set( CPACK_PACKAGE_FILE_NAME "KiCadDocumentation${PACKAGE_LANGUAGE}-${CPACK_PACKAGE_VERSION}" )
+set( CPACK_PACKAGE_FILE_NAME "kicad-doc${PACKAGE_BUILD_FORMAT}${PACKAGE_LANGUAGE}-${CPACK_PACKAGE_VERSION}" )
 include( CPack )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ project( KiCadDocumentation NONE )
 # Desired targets are DBLATEX,FOP and ASCIIDOCTOR-PDF
 set( PDF_GENERATOR "DBLATEX" CACHE STRING "Specify which PDF generator to use: DBLATEX|FOP" )
 
+# Provide an option for a single language build. If nothing else, this will at
+# least help developers to speed up a build they're working on
+set( SINGLE_LANGUAGE "" CACHE STRING "Specify a single language to build: en|fr|it|pl" )
+
 # Add our custom modules to the module path
 set( CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMakeModules" ${CMAKE_MODULE_PATH} )
 
@@ -67,10 +71,18 @@ find_package( A2X REQUIRED )
 include( KiCadDocumentation )
 add_subdirectory( src )
 
+# Set the language in the package name if the package only contains a single
+# language
+if( "${SINGLE_LANGUAGE}" STREQUAL "" )
+    set( PACKAGE_LANGUAGE "" )
+else()
+    set( PACKAGE_LANGUAGE "-${SINGLE_LANGUAGE}" )
+endif()
+
 # Generate both .tar.gz and .zip package targets
 set( CPACK_GENERATOR "TGZ;ZIP" )
 set( CPACK_PACKAGE_VERSION "1.0.0" )
-set( CPACK_PACKAGE_FILE_NAME "KiCadDocumentation-${CPACK_PACKAGE_VERSION}" )
+set( CPACK_PACKAGE_FILE_NAME "KiCadDocumentation${PACKAGE_LANGUAGE}-${CPACK_PACKAGE_VERSION}" )
 include( CPack )
 
 

--- a/CMakeModules/KiCadDocumentation.cmake
+++ b/CMakeModules/KiCadDocumentation.cmake
@@ -33,13 +33,18 @@ macro( KiCadDocumentation DOCNAME )
         file( GLOB AVAILABLE RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/po ${CMAKE_CURRENT_SOURCE_DIR}/po/*.po )
 
         # Only add the language target if it is available. If this document hasn't been
-        # translated into the required language, don't include it as a target
-        foreach( L ${AVAILABLE} )
-            if( "${L}" STREQUAL "${SINGLE_LANGUAGE}.po" )
-                # Only build the required language
-                list( APPEND TRANSLATIONS "${SINGLE_LANGUAGE}" )
-            endif()
-        endforeach()
+        # translated into the required language, don't include it as a target. English
+        # doesn't have a .po file and is always producable, so add it without any checks
+        if( ${SINGLE_LANGUAGE} STREQUAL "en" )
+            list( APPEND TRANSLATIONS "${SINGLE_LANGUAGE}" )
+        else()
+            foreach( L ${AVAILABLE} )
+                if( "${L}" STREQUAL "${SINGLE_LANGUAGE}.po" )
+                    # Only build the required language
+                    list( APPEND TRANSLATIONS "${SINGLE_LANGUAGE}" )
+                endif()
+            endforeach()
+        endif()
     endif()
 
     foreach( LANGUAGE ${TRANSLATIONS} )
@@ -79,30 +84,34 @@ macro( KiCadDocumentation DOCNAME )
 	endforeach()
 
 	# HTML Generation
+	list( FIND BUILD_FORMATS "html" HTML_BUILD )
+	if( NOT "${HTML_BUILD}" EQUAL "-1" )
+            add_adoc_html_target( ${DOCNAME}_html_${LANGUAGE}
+                    ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.adoc
+                    ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.html
+                    ${LANGUAGE} )
+
+            add_dependencies( ${DOCNAME}_html_${LANGUAGE} ${DOCNAME}_translate_${LANGUAGE} )
+            add_dependencies( ${DOCNAME} ${DOCNAME}_html_${LANGUAGE} )
+
+            install( FILES ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.html DESTINATION ./${LANGUAGE}/${DOCNAME}/html )
+            install( DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/images DESTINATION ./${LANGUAGE}/${DOCNAME}/html )
+        endif()
 	
-	add_adoc_html_target( ${DOCNAME}_html_${LANGUAGE}
-		${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.adoc
-		${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.html
-		${LANGUAGE} )
-
-	add_dependencies( ${DOCNAME}_html_${LANGUAGE} ${DOCNAME}_translate_${LANGUAGE} )
-	add_dependencies( ${DOCNAME} ${DOCNAME}_html_${LANGUAGE} )
-
-	install( FILES ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.html DESTINATION ./${LANGUAGE}/${DOCNAME}/html )
-	install( DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/images DESTINATION ./${LANGUAGE}/${DOCNAME}/html )
-
+	
 	# PDF Generation
-	
-	add_adoc_pdf_target( ${DOCNAME}_pdf_${LANGUAGE}
-		${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.adoc
-		${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.pdf
-		${LANGUAGE} )
+	list( FIND BUILD_FORMATS "pdf" PDF_BUILD )
+	if( NOT "${PDF_BUILD}" EQUAL "-1" )
+            add_adoc_pdf_target( ${DOCNAME}_pdf_${LANGUAGE}
+                    ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.adoc
+                    ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.pdf
+                    ${LANGUAGE} )
 
-	add_dependencies( ${DOCNAME}_pdf_${LANGUAGE} ${DOCNAME}_translate_${LANGUAGE} )
-	add_dependencies( ${DOCNAME} ${DOCNAME}_pdf_${LANGUAGE} )
+            add_dependencies( ${DOCNAME}_pdf_${LANGUAGE} ${DOCNAME}_translate_${LANGUAGE} )
+            add_dependencies( ${DOCNAME} ${DOCNAME}_pdf_${LANGUAGE} )
 
-	install( FILES ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.pdf DESTINATION ./${LANGUAGE}/${DOCNAME}/pdf )
-
+            install( FILES ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.pdf DESTINATION ./${LANGUAGE}/${DOCNAME}/pdf )
+        endif()
     endforeach()
 
 endmacro()

--- a/CMakeModules/KiCadDocumentation.cmake
+++ b/CMakeModules/KiCadDocumentation.cmake
@@ -20,12 +20,27 @@ macro( KiCadDocumentation DOCNAME )
 	list( APPEND DOCCHAPTERS "${CNAME}" )
     endforeach()
 
-    # Get a list of all po translation files so we know what languages can be built
-    file( GLOB TRANSLATIONS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/po ${CMAKE_CURRENT_SOURCE_DIR}/po/*.po )
+    # If we're not building a specific language, glob all languages
+    if( "${SINGLE_LANGUAGE}" STREQUAL "" )
+        # Get a list of all po translation files so we know what languages can be built
+        file( GLOB TRANSLATIONS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/po ${CMAKE_CURRENT_SOURCE_DIR}/po/*.po )
 
-    # Add English to the translations, but we'll have to treat it as a special case
-    # when generating a translation target
-    list( APPEND TRANSLATIONS en )
+        # Add English to the translations, but we'll have to treat it as a special case
+        # when generating a translation target
+        list( APPEND TRANSLATIONS en )
+    else()
+        # Get a list of all po translation files so we know what languages can be built
+        file( GLOB AVAILABLE RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/po ${CMAKE_CURRENT_SOURCE_DIR}/po/*.po )
+
+        # Only add the language target if it is available. If this document hasn't been
+        # translated into the required language, don't include it as a target
+        foreach( L ${AVAILABLE} )
+            if( "${L}" STREQUAL "${SINGLE_LANGUAGE}.po" )
+                # Only build the required language
+                list( APPEND TRANSLATIONS "${SINGLE_LANGUAGE}" )
+            endif()
+        endforeach()
+    endif()
 
     foreach( LANGUAGE ${TRANSLATIONS} )
 

--- a/cmake-readme.adoc
+++ b/cmake-readme.adoc
@@ -25,6 +25,35 @@ This will translate and build PDF and HTML versions of the documentation.
 See below for more information about the pre-requisites required for building
 the documentation.
 
+== Build Options
+
+The following options are available when configuring a build with CMake:
+
+=== BUILD_FORMATS
+
+By default **BUILD_FORMATS** is set to `html;pdf` to enable building all supported
+document formats.
+
+It's possible to set **BUILD_FORMATS** in order to build only a subset of formats,
+e.g. `-DBUILD_FORMATS=html` or `-DBUILD_FORMATS=pdf`
+    
+When only one build format is enabled the package name is transformed to include
+the format.
+
+=== SINGLE_LANGUAGE
+
+By default CMake will configure to build all languages available for each document.
+
+You can build just a single language by using the **SINGLE_LANGUAGE** option when
+configuring a build with CMake, e.g. `-DSINGLE_LANGUAGE=it`, etc.
+
+Currently, the available languages are : `en`, `fr`, `nl`, and `pl` however, any
+language code can be selected. Only translated documents will be built, so for
+some languages there may only be a partial documentation output.
+
+When the **SINGLE_LANGUAGE** option is set, the package name is transformed to
+include the language.
+
 == PO4A
 
 https://po4a.alioth.debian.org/[PO4A] 0.45+ is required. It's used to translate

--- a/cmake-readme.adoc
+++ b/cmake-readme.adoc
@@ -47,7 +47,7 @@ By default CMake will configure to build all languages available for each docume
 You can build just a single language by using the **SINGLE_LANGUAGE** option when
 configuring a build with CMake, e.g. `-DSINGLE_LANGUAGE=it`, etc.
 
-Currently, the available languages are : `en`, `fr`, `nl`, and `pl` however, any
+Currently, the available languages are : `en`, `fr`, `it`, `nl`, and `pl` however, any
 language code can be selected. Only translated documents will be built, so for
 some languages there may only be a partial documentation output.
 


### PR DESCRIPTION
Adds a single language option. Safely builds a language, even partially translated languages such as `fr`, only what is translated is included in the build.

To use this commit, configure a single language build with:

    cmake -DSINGLE_LANGUAGE=en

Available languages so far are `en|fr|it|pl`

The package name is transformed when using **SINGLE_LANGUAGE** so that the language is included in the package tarball.