### PR TITLE
Fix Issue #64 and update cmake-readme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ endif()
 
 if( ${PDF_GENERATOR} MATCHES FOP )
     add_a2x_option( --fop )
+    add_a2x_option( --xsl-file ${PROJECT_SOURCE_DIR}/xsl/kicad.xsl )
     find_package( FOP REQUIRED )
 endif()
 

--- a/cmake-readme.adoc
+++ b/cmake-readme.adoc
@@ -54,17 +54,32 @@ some languages there may only be a partial documentation output.
 When the **SINGLE_LANGUAGE** option is set, the package name is transformed to
 include the language.
 
-== PO4A
+=== PDF_GENERATOR
+
+By default CMake will use dblatex building PDFs.
+
+You can build PDFs however using either `DBLATEX` or `FOP` by using the
+**PDF_GENERATOR** option whilst configuring a CMake build.
+
+For example, use `-DPDF_GENERATOR=FOP` to use FOP to build the PDFs. If the
+**BUILD_FORMATS** option doesn't include `pdf`, the **PDF_GENERATOR** option
+will have no effect on the build.
+
+This option doesn't transform the built package name.
+
+== Dependencies
+
+=== PO4A
 
 https://po4a.alioth.debian.org/[PO4A] 0.45+ is required. It's used to translate
 the English asciidoc documentation to another language before compilation to a
 final output format.
 
-=== PO4A on Linux
+==== PO4A on Linux
 
 Use your package manager to get the PO4A tools.
 
-=== PO4A on Windows
+==== PO4A on Windows
 
 PO4A is a perl script and so requires PERL to be installed. If you're using a
 POSIX emulation layer with package management, grab the perl package.
@@ -90,19 +105,19 @@ MinGW compiler which it uses to compile perl modules. Usually it puts this at
 the start of your path so this version of the MinGW compiler becomes your
 default compiler!
 
-== ASCIIDOC
+=== ASCIIDOC
 
 http://asciidoc.org/[AsciiDoc] is also required for building the documentation.
 
 Asciidoc is the format of the documentation and is used to generate both PDF
 and HTML versions of the documentation.
 
-=== Linux
+==== Linux
 
 Grab your distribution's ASCIIDOC package which will also install asciidoc's
 pre-requisites too.
 
-=== Windows
+==== Windows
 
 To install asciidoc on windows, get the latest version from
 http://sourceforge.net/projects/asciidoc/[Sourceforge] and unzip somewhere on
@@ -116,7 +131,7 @@ ourselves.
 
 Details of how to install dblatex and FOP are included below.
 
-== dblatex on Windows
+=== dblatex on Windows
 
 WARNING: Although dblatex support is provided for under Windows, it has only
 been unsuccessfully tested, failing due to a race condition with file
@@ -167,7 +182,7 @@ CMakeSupport/windows directory in your path and modifying it as necessary.
 So long as the install works, CMake will be able to find dblatex in your
 python installation
 
-== FOP on Windows
+=== FOP on Windows
 
 NOTE: This is currently the only way of building PDF documents on Windows.
 
@@ -180,7 +195,7 @@ In order for CMake to use FOP, use the following when configuring with CMake:
 
     -DPDF_GENERATOR=FOP
 
-== ASCIIDOCTOR
+=== ASCIIDOCTOR
 
 WARNING: ASCIIDOCTOR is not currently supported!
 

--- a/xsl/kicad.xsl
+++ b/xsl/kicad.xsl
@@ -1,0 +1,262 @@
+<!--
+  Generates single FO document from DocBook XML source using DocBook XSL
+  stylesheets.
+
+  See xsl-stylesheets/fo/param.xsl for all parameters.
+
+  NOTE: The URL reference to the current DocBook XSL stylesheets is
+  rewritten to point to the copy on the local disk drive by the XML catalog
+  rewrite directives so it doesn't need to go out to the Internet for the
+  stylesheets. This means you don't need to edit the <xsl:import> elements on
+  a machine by machine basis.
+-->
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:fo="http://www.w3.org/1999/XSL/Format">
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
+<xsl:param name="html.stylesheet" select="'docbook-xsl.css'"/>
+
+<xsl:param name="htmlhelp.chm" select="'htmlhelp.chm'"/>
+<xsl:param name="htmlhelp.hhc.section.depth" select="5"/>
+
+<xsl:param name="section.autolabel">
+  <xsl:choose>
+    <xsl:when test="/processing-instruction('asciidoc-numbered')">1</xsl:when>
+    <xsl:otherwise>0</xsl:otherwise>
+  </xsl:choose>
+</xsl:param>
+
+<xsl:param name="suppress.navigation" select="0"/>
+<xsl:param name="navig.graphics.extension" select="'.png'"/>
+<xsl:param name="navig.graphics" select="0"/>
+<xsl:param name="navig.graphics.path">images/icons/</xsl:param>
+<xsl:param name="navig.showtitles">0</xsl:param>
+
+<xsl:param name="shade.verbatim" select="0"/>
+<xsl:attribute-set name="shade.verbatim.style">
+  <xsl:attribute name="border">0</xsl:attribute>
+  <xsl:attribute name="background-color">#E0E0E0</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:param name="admon.graphics" select="1"/>
+<xsl:param name="admon.graphics.path">images/icons/</xsl:param>
+<xsl:param name="admon.graphics.extension" select="'.png'"/>
+<xsl:param name="admon.style">
+  <xsl:text>margin-left: 0; margin-right: 10%;</xsl:text>
+</xsl:param>
+<xsl:param name="admon.textlabel" select="1"/>
+
+<xsl:param name="callout.defaultcolumn" select="'60'"/>
+<xsl:param name="callout.graphics.extension" select="'.png'"/>
+<xsl:param name="callout.graphics" select="'1'"/>
+<xsl:param name="callout.graphics.number.limit" select="'10'"/>
+<xsl:param name="callout.graphics.path" select="'images/icons/callouts/'"/>
+<xsl:param name="callout.list.table" select="'1'"/>
+
+<!-- This does not seem to work. -->
+<xsl:param name="section.autolabel.max.depth" select="2"/>
+
+<xsl:param name="chunk.first.sections" select="1"/>
+<xsl:param name="chunk.section.depth" select="1"/>
+<xsl:param name="chunk.quietly" select="0"/>
+<xsl:param name="chunk.toc" select="''"/>
+<xsl:param name="chunk.tocs.and.lots" select="0"/>
+
+<xsl:param name="html.cellpadding" select="'4px'"/>
+<xsl:param name="html.cellspacing" select="''"/>
+
+<xsl:param name="table.borders.with.css" select="1"/>
+<xsl:param name="table.cell.border.color" select="'#527bbd'"/>
+
+<xsl:param name="table.cell.border.style" select="'solid'"/>
+<xsl:param name="table.cell.border.thickness" select="'1px'"/>
+<xsl:param name="table.footnote.number.format" select="'a'"/>
+<xsl:param name="table.footnote.number.symbols" select="''"/>
+<xsl:param name="table.frame.border.color" select="'#527bbd'"/>
+<xsl:param name="table.frame.border.style" select="'solid'"/>
+<xsl:param name="table.frame.border.thickness" select="'3px'"/>
+<xsl:param name="tablecolumns.extension" select="'1'"/>
+
+<xsl:param name="highlight.source" select="1"/>
+
+<xsl:param name="section.label.includes.component.label" select="1"/>
+
+<!--
+  Table of contents inserted by <?asciidoc-toc?> processing instruction.
+-->
+<xsl:param name="generate.toc">
+  <xsl:choose>
+    <xsl:when test="/processing-instruction('asciidoc-toc')">
+article toc,title
+book    toc,title,figure,table,example,equation
+      <!-- The only way I could find that suppressed book chapter TOCs -->
+      <xsl:if test="$generate.section.toc.level != 0">
+chapter   toc,title
+part      toc,title
+preface   toc,title
+qandadiv  toc
+qandaset  toc
+reference toc,title
+sect1     toc
+sect2     toc
+sect3     toc
+sect4     toc
+sect5     toc
+section   toc
+set       toc,title
+      </xsl:if>
+    </xsl:when>
+    <xsl:otherwise>
+article nop
+book    nop
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:param>
+
+<xsl:param name="fop1.extensions" select="1" />
+<xsl:param name="variablelist.as.blocks" select="1" />
+
+<xsl:param name="paper.type" select="'A4'"/>
+<!--
+<xsl:param name="paper.type" select="'USletter'"/>
+-->
+<xsl:param name="hyphenate">false</xsl:param>
+<!-- justify, left or right -->
+<xsl:param name="alignment">left</xsl:param>
+
+<xsl:param name="body.font.family" select="'serif'"/>
+<xsl:param name="body.font.master">12</xsl:param>
+<xsl:param name="body.font.size">
+ <xsl:value-of select="$body.font.master"/><xsl:text>pt</xsl:text>
+</xsl:param>
+
+<xsl:param name="body.margin.bottom" select="'0.5in'"/>
+<xsl:param name="body.margin.top" select="'0.5in'"/>
+<xsl:param name="bridgehead.in.toc" select="0"/>
+
+<!-- overide setting in common.xsl -->
+<xsl:param name="table.frame.border.thickness" select="'2px'"/>
+
+<!-- Default fetches image from Internet (long timeouts) -->
+<xsl:param name="draft.watermark.image" select="''"/>
+
+<!-- Line break -->
+<xsl:template match="processing-instruction('asciidoc-br')">
+  <fo:block/>
+</xsl:template>
+
+<!-- Horizontal ruler -->
+<xsl:template match="processing-instruction('asciidoc-hr')">
+  <fo:block space-after="1em">
+    <fo:leader leader-pattern="rule" rule-thickness="0.5pt"  rule-style="solid" leader-length.minimum="100%"/>
+  </fo:block>
+</xsl:template>
+
+<!-- Hard page break -->
+<xsl:template match="processing-instruction('asciidoc-pagebreak')">
+   <fo:block break-after='page'/>
+</xsl:template>
+
+<!-- Sets title to body text indent -->
+<xsl:param name="body.start.indent">
+  <xsl:choose>
+    <xsl:when test="$fop.extensions != 0">0pt</xsl:when>
+    <xsl:when test="$passivetex.extensions != 0">0pt</xsl:when>
+    <xsl:otherwise>1pc</xsl:otherwise>
+  </xsl:choose>
+</xsl:param>
+<xsl:param name="title.margin.left">
+  <xsl:choose>
+    <xsl:when test="$fop.extensions != 0">-1pc</xsl:when>
+    <xsl:when test="$passivetex.extensions != 0">0pt</xsl:when>
+    <xsl:otherwise>0pt</xsl:otherwise>
+  </xsl:choose>
+</xsl:param>
+<xsl:param name="page.margin.bottom" select="'0.25in'"/>
+<xsl:param name="page.margin.inner">
+  <xsl:choose>
+    <xsl:when test="$double.sided != 0">0.75in</xsl:when>
+    <xsl:otherwise>0.75in</xsl:otherwise>
+  </xsl:choose>
+</xsl:param>
+<xsl:param name="page.margin.outer">
+  <xsl:choose>
+    <xsl:when test="$double.sided != 0">0.5in</xsl:when>
+    <xsl:otherwise>0.5in</xsl:otherwise>
+  </xsl:choose>
+</xsl:param>
+
+<xsl:param name="page.margin.top" select="'0.5in'"/>
+<xsl:param name="page.orientation" select="'portrait'"/>
+<xsl:param name="page.width">
+  <xsl:choose>
+    <xsl:when test="$page.orientation = 'portrait'">
+      <xsl:value-of select="$page.width.portrait"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="$page.height.portrait"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:param>
+
+<xsl:attribute-set name="monospace.properties">
+  <xsl:attribute name="font-size">10pt</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:attribute-set name="admonition.title.properties">
+  <xsl:attribute name="font-size">14pt</xsl:attribute>
+  <xsl:attribute name="font-weight">bold</xsl:attribute>
+  <xsl:attribute name="hyphenate">false</xsl:attribute>
+  <xsl:attribute name="keep-with-next.within-column">always</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:attribute-set name="sidebar.properties" use-attribute-sets="formal.object.properties">
+  <xsl:attribute name="border-style">solid</xsl:attribute>
+  <xsl:attribute name="border-width">1pt</xsl:attribute>
+  <xsl:attribute name="border-color">silver</xsl:attribute>
+  <xsl:attribute name="background-color">#ffffee</xsl:attribute>
+  <xsl:attribute name="padding-left">12pt</xsl:attribute>
+  <xsl:attribute name="padding-right">12pt</xsl:attribute>
+  <xsl:attribute name="padding-top">6pt</xsl:attribute>
+  <xsl:attribute name="padding-bottom">6pt</xsl:attribute>
+  <xsl:attribute name="margin-left">0pt</xsl:attribute>
+  <xsl:attribute name="margin-right">12pt</xsl:attribute>
+  <xsl:attribute name="margin-top">6pt</xsl:attribute>
+  <xsl:attribute name="margin-bottom">6pt</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:param name="callout.graphics" select="'1'"/>
+
+<!-- Only shade programlisting and screen verbatim elements -->
+<xsl:param name="shade.verbatim" select="1"/>
+<xsl:attribute-set name="shade.verbatim.style">
+  <xsl:attribute name="background-color">
+    <xsl:choose>
+      <xsl:when test="self::programlisting|self::screen">#E0E0E0</xsl:when>
+      <xsl:otherwise>inherit</xsl:otherwise>
+    </xsl:choose>
+  </xsl:attribute>
+</xsl:attribute-set>
+
+<!--
+  Force XSL Stylesheets 1.72 default table breaks to be the same as the current
+  version (1.74) default which (for tables) is keep-together="auto".
+-->
+<xsl:attribute-set name="table.properties">
+  <xsl:attribute name="keep-together.within-column">auto</xsl:attribute>
+</xsl:attribute-set>
+
+<xsl:template match="imagedata">
+    <fo:block line-height="1pt">
+        <fo:external-graphic content-width="scale-down-to-fit" content-height="100%" width="100%" scaling="uniform">
+            <xsl:attribute name="src">
+                url(
+                <xsl:value-of select="@fileref"/>
+                )
+            </xsl:attribute>
+        </fo:external-graphic>
+    </fo:block>
+</xsl:template>
+
+
+</xsl:stylesheet>


### PR DESCRIPTION
Fixes the problem with image sizes when using FOP by bringing the fo.xsl into our build system and applying the `scale-down-to-fit`attribute to all images.

The only thing missing from the FOP build now is front covers for the manuals, which I can personally live without, but I'm sure could be added if someone fancies them.