### PR TITLE
modify doctype and fix some typo

### DIFF
--- a/src/CvPcb/CvPcb.adoc
+++ b/src/CvPcb/CvPcb.adoc
@@ -1,5 +1,5 @@
-:author: The KiCad Team
-:doctype: article
+﻿:author: The KiCad Team
+:doctype: book
 :toc:
 :ascii-ids:
 

--- a/src/Eeschema/Eeschema_generic_commands.adoc
+++ b/src/Eeschema/Eeschema_generic_commands.adoc
@@ -1,4 +1,4 @@
-
+﻿
 Generic Eeschema commands
 -------------------------
 
@@ -175,8 +175,7 @@ Tools to initialize a project are not available, because these tools are in the 
 |Open a schematic (only in standalone mode).
 
 |image:images/icons/save.png[icons/save_png]
-a|
-Save complete (hierarchical) schematic.
+|Save complete (hierarchical) schematic.
 
 |image:images/icons/sheetset.png[Page Settings icon]
 |Select the sheet size and edit the title block.

--- a/src/Eeschema/Eeschema_libedit_complements.adoc
+++ b/src/Eeschema/Eeschema_libedit_complements.adoc
@@ -1,4 +1,4 @@
-
+﻿
 [[libedit-complements]]
 LibEdit – Complements
 ---------------------
@@ -157,7 +157,7 @@ inputs NOR gate).
 * ADC, DAC, MUX…
 * OpenCol for the gates with open collector output. Thus if in the
 schematic capture software, you search the component: by keys words
-NAND2 OpenCol EES chema will display the list of components having these
+NAND2 OpenCol Eeschema will display the list of components having these
 2 key words.
 
 [[component-documentation-doc]]

--- a/src/IDF_Exporter/IDF_Exporter.adoc
+++ b/src/IDF_Exporter/IDF_Exporter.adoc
@@ -1,5 +1,5 @@
-:author: The KiCad Team
-:doctype: article
+﻿:author: The KiCad Team
+:doctype: book
 :toc:
 :ascii-ids:
 

--- a/src/KiCad/KiCad.adoc
+++ b/src/KiCad/KiCad.adoc
@@ -1,5 +1,5 @@
-:author: The KiCad Team
-:doctype: article
+﻿:author: The KiCad Team
+:doctype: book
 :toc:
 :ascii-ids:
 

--- a/src/Pcbnew/Pcbnew_installation.adoc
+++ b/src/Pcbnew/Pcbnew_installation.adoc
@@ -1,4 +1,4 @@
-
+﻿
 Installation
 ------------
 
@@ -172,7 +172,7 @@ For example:
 
      https://github.com/liftoff-sr/pretty_footprints
 
-Tpically GitHub URLs take the form:
+Typically GitHub URLs take the form:
 
      https://github.com/user_name/repo_name
 

--- a/src/Pl_Editor/Pl_Editor.adoc
+++ b/src/Pl_Editor/Pl_Editor.adoc
@@ -43,8 +43,7 @@ _https://launchpad.net/~kicad-developers_
 may 23, 2015.
 
 [[introduction-to-pl_editor]]
-Introduction to *Pl_Editor*
--------------------------
+== Introduction to *Pl_Editor* ==
 
 Pl_Editor is a page layout editor tool to create custom title blocks,
 and frame references.

--- a/src/Pl_Editor/Pl_Editor.adoc
+++ b/src/Pl_Editor/Pl_Editor.adoc
@@ -1,5 +1,5 @@
-:author: The KiCad Team
-:doctype: article
+﻿:author: The KiCad Team
+:doctype: book
 :toc:
 :ascii-ids:
 


### PR DESCRIPTION
modify `:doctype:` from `article` to `book`, CvPcb, IDF_Exporter, KiCad and Pl_Editor.
GUI_Translation_HOWTO.adoc seems not a book, so I left this as `article`.
fix some typo in Eeschema and Pcbnew.
