### PR TITLE
Compile epub with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set( PDF_GENERATOR "DBLATEX" CACHE STRING "Specify which PDF generator to use: D
 set( SINGLE_LANGUAGE "" CACHE STRING "Specify a single language to build: en|fr|it|ja|nl|pl" )
 
 # Provide an option to decide which documentation formats to build.
-set( BUILD_FORMATS "html;pdf" CACHE LIST "Specify which output formats to build html/pdf" )
+set( BUILD_FORMATS "html;pdf;epub" CACHE LIST "Specify which output formats to build html/pdf/epub" )
 
 # Add our custom modules to the module path
 set( CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMakeModules" ${CMAKE_MODULE_PATH} )

--- a/CMakeModules/AsciidocHelpers.cmake
+++ b/CMakeModules/AsciidocHelpers.cmake
@@ -51,6 +51,16 @@ macro( add_adoc_html_target TARGET INFILE OUTFILE LANGUAGE )
     add_custom_target( ${TARGET} ALL ${ASCIIDOC_COMMAND} ${ASCIIDOC_OPTIONS} ${LANGUAGE_OPTIONS} -o ${OUTFILE} ${INFILE} )
 endmacro()
 
+# Add an asciidoc to EPUB conversion target
+macro( add_adoc_epub_target TARGET INFILE OUTFILE LANGUAGE )
+    set( TITLE "${TARGET}" )
+    string(REGEX REPLACE "_epub_.." "" DOCINFO_OUT "${LANGUAGE}/${TARGET}-docinfo.xml" )
+    configure_file( ${CMAKE_SOURCE_DIR}/CMakeSupport/epub-cover-docinfo-template.xml # Prepare cover docinfo
+                    ${DOCINFO_OUT} )
+    set( _A2X_OPTIONS -f epub -a docinfo )
+    add_custom_target( ${TARGET} ALL ${A2X_COMMAND} ${_A2X_OPTIONS} ${INFILE} )
+endmacro()
+
 # Pass an option to asciidoc
 macro( add_adoc_option )
     foreach( OPT ${ARGN} )

--- a/CMakeModules/KiCadDocumentation.cmake
+++ b/CMakeModules/KiCadDocumentation.cmake
@@ -131,6 +131,21 @@ macro( KiCadDocumentation DOCNAME )
 
             install( FILES ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.pdf DESTINATION ./${LANGUAGE}/${DOCNAME}/pdf )
         endif()
+
+
+        # EPUB Generation
+        list( FIND BUILD_FORMATS "epub" EPUB_BUILD )
+        if( NOT "${EPUB_BUILD}" EQUAL "-1" )
+            add_adoc_epub_target( ${DOCNAME}_epub_${LANGUAGE}
+                    ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.adoc
+                    ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.epub
+                    ${LANGUAGE} )
+
+            add_dependencies( ${DOCNAME}_epub_${LANGUAGE} ${DOCNAME}_translate_${LANGUAGE} )
+            add_dependencies( ${DOCNAME} ${DOCNAME}_epub_${LANGUAGE} )
+
+            install( FILES ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}/${DOCNAME}.epub DESTINATION ./${LANGUAGE}/${DOCNAME}/epub )
+        endif()
     endforeach()
 
 endmacro()

--- a/CMakeSupport/epub-cover-docinfo-template.xml
+++ b/CMakeSupport/epub-cover-docinfo-template.xml
@@ -1,0 +1,8 @@
+<mediaobject role="cover">
+  <imageobject>
+   <imagedata fileref="images/logo.png" format="PNG"/>
+  </imageobject>
+  <textobject>
+    <phrase>${TITLE}</phrase>
+  </textobject>
+</mediaobject>


### PR DESCRIPTION
Compilation of epub with CMake the same as for PDF. I reused the docinfo cover page from the legacy Makefile.
Hopefully there is not much more to do before removing the legacy Makefile and related make.sh